### PR TITLE
:zap: Improve Beacon Chain mock

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -50,7 +50,7 @@ include_push_bytes = true
 forge-std = "1.9.7"
 solmate = "6.8.0"
 solady = "0.1.23"
-"origin-dollar" = { version = "1.0.0", git = "git@github.com:OriginProtocol/origin-dollar.git", rev = "ba180065b4f4a8cd847f7af11bf51ad815413d90" }
+"origin-dollar" = { version = "1.0.0", git = "git@github.com:OriginProtocol/origin-dollar.git", rev = "546c47f2a2fa91acc2c72466476a149163dfa99b" }
 "openzeppelin-contracts-4.4.2" = { version = "4.4.2", git = "git@github.com:OpenZeppelin/openzeppelin-contracts.git", rev = "b53c43242fc9c0e435b66178c3847c4a1b417cc1" }
 
 

--- a/src/BeaconChain.sol
+++ b/src/BeaconChain.sol
@@ -214,8 +214,8 @@ contract BeaconChain {
         Validator storage validator = validators[getValidatorIndex(pubkey)];
 
         // Ensure validator is in correct state to process withdrawal
-        if (validator.status != Status.DEPOSITED && validator.status != Status.ACTIVE) {
-            emit BeaconChain___WithdrawNotProcessed(pubkey, "Validator not in DEPOSITED or ACTIVE state");
+        if (validator.status != Status.ACTIVE) {
+            emit BeaconChain___WithdrawNotProcessed(pubkey, "Validator not ACTIVE state");
             return;
         }
 

--- a/src/BeaconChain.sol
+++ b/src/BeaconChain.sol
@@ -200,6 +200,7 @@ contract BeaconChain {
     /// @dev Only the owner can request withdrawal.
     function withdraw(bytes calldata pubkey, uint256 amount) external {
         Validator memory validator = validators[getValidatorIndex(pubkey)];
+        if (validator.status != ValidatorStatus.ACTIVE) return; // Only ACTIVE validators can request withdrawal
         require(validator.owner == msg.sender, "Only owner can request withdrawal");
         require(validator.amount >= amount, "Insufficient validator balance");
 

--- a/src/BeaconChain.sol
+++ b/src/BeaconChain.sol
@@ -469,7 +469,11 @@ contract BeaconChain {
 
         // Force exit if validator is still active or deposited
         Validator storage validator = validators[getValidatorIndex(pubkey)];
-        if (validator.status == Status.DEPOSITED || validator.status == Status.ACTIVE) {
+        if (validator.status == Status.DEPOSITED) {
+            validator.status = Status.EXITED;
+            emit BeaconChain___StatusChanged(pubkey, validator.amount, Status.DEPOSITED, Status.EXITED);
+        }
+        if (validator.status == Status.ACTIVE) {
             validator.slashedAmount += MIN_SLASHING_PENALTY; // Apply minimum slashing penalty
             validator.status = Status.EXITED;
             emit BeaconChain___ValidatorSlashed(pubkey, MIN_SLASHING_PENALTY);

--- a/src/BeaconChain.sol
+++ b/src/BeaconChain.sol
@@ -162,7 +162,7 @@ contract BeaconChain {
     /// @notice Processes multiple deposits from the deposit queue.
     /// @param count The number of deposits to process.
     /// @dev Processes up to `count` deposits, or all if `count` exceeds the queue length.
-    function processDeposits(
+    function processDeposit(
         uint256 count
     ) public {
         uint256 len = min(depositQueue.length, count);
@@ -171,9 +171,16 @@ contract BeaconChain {
         }
     }
 
-    /// @notice Goes through all validators and activates those that are `DEPOSITED` and have enough ETH.
+    /// @notice Activates all eligible validators.
     function activateValidators() public {
-        uint256 len = validators.length;
+        activateValidators(validators.length);
+    }
+
+    /// @notice Goes through all validators and activates those that are `DEPOSITED` and have enough ETH.
+    function activateValidators(
+        uint256 count
+    ) public {
+        uint256 len = min(validators.length, count);
         for (uint256 i; i < len; i++) {
             Validator storage validator = validators[i];
             if (validator.status == ValidatorStatus.DEPOSITED && validator.amount >= ACTIVATION_AMOUNT) {

--- a/src/BeaconChain.sol
+++ b/src/BeaconChain.sol
@@ -212,6 +212,9 @@ contract BeaconChain {
         // Get the validator index corresponding to the pubkey, it must exist
         Validator storage validator = validators[getValidatorIndex(pubkey)];
 
+        // If amount is 0 this is a full withdrawal
+        if (pendingWithdrawal.amount == 0) pendingWithdrawal.amount = validator.amount;
+
         // Ensure validator is in correct state to process withdrawal
         if (validator.status != Status.DEPOSITED && validator.status != Status.ACTIVE) {
             emit BeaconChain___WithdrawNotProcessed(pubkey, "Validator not in DEPOSITED or ACTIVE state");

--- a/src/BeaconChain.sol
+++ b/src/BeaconChain.sol
@@ -188,13 +188,9 @@ contract BeaconChain {
     /// @param amount The amount to withdraw. If 0, it means full withdrawal.
     /// @dev Only the owner can request withdrawal.
     function withdraw(bytes calldata pubkey, uint256 amount) external {
-        Validator memory validator = validators[getValidatorIndex(pubkey)];
-        if (validator.status != Status.ACTIVE) return; // Only ACTIVE validators can request withdrawal
-
         withdrawQueue.push(
             Queue({ pubkey: pubkey, amount: amount, timestamp: uint64(block.timestamp), owner: address(0), uid: 0 })
         );
-
         emit BeaconChain___Withdraw(pubkey, amount);
     }
 

--- a/src/BeaconChain.sol
+++ b/src/BeaconChain.sol
@@ -227,7 +227,7 @@ contract BeaconChain {
         Validator storage validator = validators[getValidatorIndex(pubkey)];
 
         // Ensure the validator has enough balance and deduct the amount
-        if (validator.amount < pendingWithdrawal.amount + ACTIVATION_AMOUNT) {
+        if (validator.amount < pendingWithdrawal.amount) {
             emit INSUFFICIENT_VALIDATOR_BALANCE(pubkey, validator.amount, pendingWithdrawal.amount);
             return; // Incorrect withdraw request, ignored
         }

--- a/src/BeaconChain.sol
+++ b/src/BeaconChain.sol
@@ -458,13 +458,10 @@ contract BeaconChain {
     ) public {
         require(ssvRegisteredValidators[pubkey], "Validator not registered");
 
-        // Force exit if validator is still active or deposited
-        Validator storage validator = validators[getValidatorIndex(pubkey)];
-        if (validator.status == Status.DEPOSITED) {
-            validator.status = Status.EXITED;
-            emit BeaconChain___StatusChanged(pubkey, validator.amount, Status.DEPOSITED, Status.EXITED);
-        }
-        if (validator.status == Status.ACTIVE) slash(pubkey, MIN_SLASHING_PENALTY); // Slash and exit
+        if (validators[getValidatorIndex(pubkey)].status == Status.DEPOSITED) return; // Cannot remove if still DEPOSITED
+
+        // Force exit if validator is still active
+        if (validators[getValidatorIndex(pubkey)].status == Status.ACTIVE) slash(pubkey, MIN_SLASHING_PENALTY);
 
         ssvRegisteredValidators[pubkey] = false;
         emit SSVNetwork___ValidatorRemoved(pubkey);

--- a/src/BeaconChain.sol
+++ b/src/BeaconChain.sol
@@ -66,7 +66,6 @@ contract BeaconChain {
     Queue[] public withdrawQueue;
     Validator[] public validators; // unordered list of validator
 
-    uint256 public uniqueDepositId = 100; // unique identifier for deposits, starting at 100 to avoid confusion with 0
     mapping(bytes32 id => bool processed) public processedDeposits; // to help tracking processed deposits
     mapping(bytes pubkey => bool registered) public ssvRegisteredValidators; // mapping of SSV registered validators
 
@@ -522,11 +521,6 @@ contract BeaconChain {
     /// @return The minimum value.
     function min(uint256 a, uint256 b) public pure returns (uint256) {
         return a < b ? a : b;
-    }
-
-    /// @notice Increases the unique deposit ID (for testing purposes).
-    function increaseUniqueDepositId() public {
-        uniqueDepositId++;
     }
 
     /// @notice Sets the BeaconProofs contract address.

--- a/src/BeaconChain.sol
+++ b/src/BeaconChain.sol
@@ -49,7 +49,7 @@ contract BeaconChain {
         uint64 timestamp;
         uint256 amount; // in wei
         address owner;
-        bytes32 uid;
+        bytes32 udid;
     }
 
     struct Validator {
@@ -120,9 +120,9 @@ contract BeaconChain {
                 pubkey: pubkey,
                 timestamp: uint64(block.timestamp),
                 owner: decodeOwner(withdrawalCredentials),
-                // recreate the pendingDepositRoot, that will be used as unique identifier of the deposit
+                // recreate the pendingDepositRoot, that will be used as unique deposit ID
                 // signature is the value responsible to make the deposit unique
-                uid: beaconProofs.merkleizePendingDeposit({
+                udid: beaconProofs.merkleizePendingDeposit({
                     pubKeyHash: beaconProofs.hashPubKey(pubkey),
                     withdrawalCredentials: withdrawalCredentials,
                     amountGwei: (msg.value / 1 gwei).toUint64(),
@@ -160,7 +160,7 @@ contract BeaconChain {
                     status: Status.DEPOSITED
                 })
             );
-            processedDeposits[pendingDeposit.uid] = true;
+            processedDeposits[pendingDeposit.udid] = true;
             emit BeaconChain___ValidatorCreated(pubkey);
             emit BeaconChain___StatusChanged(pubkey, pendingDeposit.amount, Status.UNKNOWN, Status.DEPOSITED);
             emit BeaconChain___DepositProcessed(pubkey, pendingDeposit.amount, Status.DEPOSITED);
@@ -182,7 +182,7 @@ contract BeaconChain {
 
         // --- 2.c. Validator exists and is either DEPOSITED, ACTIVE or WITHDRAWABLE: increase stake
         validator.amount += pendingDeposit.amount;
-        processedDeposits[pendingDeposit.uid] = true;
+        processedDeposits[pendingDeposit.udid] = true;
         emit BeaconChain___DepositProcessed(pubkey, pendingDeposit.amount, currentStatus);
     }
 
@@ -208,7 +208,7 @@ contract BeaconChain {
     /// @dev Only the owner can request withdrawal.
     function withdraw(bytes calldata pubkey, uint256 amount) external {
         withdrawQueue.push(
-            Queue({ pubkey: pubkey, amount: amount, timestamp: uint64(block.timestamp), owner: address(0), uid: 0 })
+            Queue({ pubkey: pubkey, amount: amount, timestamp: uint64(block.timestamp), owner: address(0), udid: 0 })
         );
         emit BeaconChain___Withdraw(pubkey, amount);
     }

--- a/src/BeaconChain.sol
+++ b/src/BeaconChain.sol
@@ -281,7 +281,7 @@ contract BeaconChain {
 
     /// @notice Goes through all validators and change status from EXITED to WITHDRAWABLE.
     /// @dev This function is used to simulate the exit delay, but does not enforce any time-based logic.
-    function desactivateValidator(
+    function deactivateValidator(
         uint256 count
     ) public {
         // First count validators in EXITED state
@@ -307,15 +307,15 @@ contract BeaconChain {
     }
 
     /// @notice Desactivate all exited validators.
-    function desactivateValidator() public {
-        desactivateValidator(validators.length);
+    function deactivateValidator() public {
+        deactivateValidator(validators.length);
     }
 
     /// @notice Get through all active validators and process if status is:
     /// - UNKNOWN: revert as should never happen
     /// - DEPOSITED: do nothing, waiting either for more deposits or activateValidators to be called
     /// - ACTIVE: remove all amount above 2048 ETH, assuming only 0x02 validators
-    /// - EXITED: do nothing, waiting for desactivateValidator to be called and move to WITHDRAWABLE
+    /// - EXITED: do nothing, waiting for deactivateValidator to be called and move to WITHDRAWABLE
     /// - WITHDRAWABLE: transfer all amount to owner and set amount to 0
     function processSweep() public {
         for (uint256 i = 0; i < validators.length; i++) {

--- a/src/BeaconChain.sol
+++ b/src/BeaconChain.sol
@@ -57,7 +57,7 @@ contract BeaconChain {
     Queue[] public depositQueue;
     Queue[] public withdrawQueue;
     Validator[] public validators; // unordered list of validator
-    mapping(bytes pubkey => bool registered) public ssvRegistreredValidators; // mapping of SSV registered validators
+    mapping(bytes pubkey => bool registered) public ssvRegisteredValidators; // mapping of SSV registered validators
 
     ////////////////////////////////////////////////////
     /// --- ERRORS & EVENTS
@@ -100,7 +100,7 @@ contract BeaconChain {
         bytes32 /*deposit_data_root*/
     ) public payable {
         require(msg.value >= MIN_DEPOSIT, "Minimum deposit is 1 ETH");
-        require(ssvRegistreredValidators[pubkey], "Validator not registered in SSVNetwork");
+        require(ssvRegisteredValidators[pubkey], "Validator not registered in SSVNetwork");
         depositQueue.push(
             Queue({
                 amount: msg.value,
@@ -424,8 +424,8 @@ contract BeaconChain {
     ) public {
         Validator memory validator = validators[getValidatorIndex(pubkey)];
         require(validator.status == Status.UNKNOWN, "Validator already exists");
-        require(!ssvRegistreredValidators[pubkey], "Validator already registered");
-        ssvRegistreredValidators[pubkey] = true;
+        require(!ssvRegisteredValidators[pubkey], "Validator already registered");
+        ssvRegisteredValidators[pubkey] = true;
 
         emit SSVNetwork___ValidatorRegistered(pubkey);
     }
@@ -436,7 +436,7 @@ contract BeaconChain {
     function removeSsvValidator(
         bytes memory pubkey
     ) public {
-        require(ssvRegistreredValidators[pubkey], "Validator not registered");
+        require(ssvRegisteredValidators[pubkey], "Validator not registered");
 
         // Force exit if validator is still active or deposited
         Validator storage validator = validators[getValidatorIndex(pubkey)];
@@ -447,7 +447,7 @@ contract BeaconChain {
             emit BeaconChain___StatusChanged(pubkey, validator.amount, validator.status, Status.EXITED);
         }
 
-        ssvRegistreredValidators[pubkey] = false;
+        ssvRegisteredValidators[pubkey] = false;
         emit SSVNetwork___ValidatorRemoved(pubkey);
     }
 

--- a/src/BeaconChain.sol
+++ b/src/BeaconChain.sol
@@ -71,7 +71,7 @@ contract BeaconChain {
 
     // Validators events
     event BeaconChain___ValidatorCreated(bytes pubkey);
-    event BeaconChain___ValidatorActivated(bytes pubkey);
+    event BeaconChain___ValidatorActivated(bytes pubkey, uint256 amount);
     event BeaconChain___ValidatorExited(bytes pubkey);
     event BeaconChain___ValidatorWithdrawable(bytes pubkey);
     event BeaconChain___ValidatorSlashed(bytes pubkey, uint256 amount);
@@ -178,7 +178,7 @@ contract BeaconChain {
             Validator storage validator = validators[i];
             if (validator.status == ValidatorStatus.DEPOSITED && validator.amount >= ACTIVATION_AMOUNT) {
                 validator.status = ValidatorStatus.ACTIVE;
-                emit BeaconChain___ValidatorActivated(validator.pubkey);
+                emit BeaconChain___ValidatorActivated(validator.pubkey, validator.amount);
             }
         }
     }

--- a/src/BeaconChain.sol
+++ b/src/BeaconChain.sol
@@ -172,7 +172,7 @@ contract BeaconChain {
     }
 
     /// @notice Goes through all validators and activates those that are `DEPOSITED` and have enough ETH.
-    function activateValidator() public {
+    function activateValidators() public {
         uint256 len = validators.length;
         for (uint256 i; i < len; i++) {
             Validator storage validator = validators[i];
@@ -486,7 +486,7 @@ contract BeaconChain {
 
 // --- List of actions ---
 // processDeposit
-// activateValidator
+// activateValidators
 // processExit
 // processWithdraw
 // processSweep

--- a/src/BeaconChain.sol
+++ b/src/BeaconChain.sol
@@ -422,9 +422,8 @@ contract BeaconChain {
     function registerSsvValidator(
         bytes memory pubkey
     ) public {
-        Validator memory validator = validators[getValidatorIndex(pubkey)];
-        require(validator.status == Status.UNKNOWN, "Validator already exists");
         require(!ssvRegisteredValidators[pubkey], "Validator already registered");
+        require(getValidatorIndex(pubkey) == NOT_FOUND, "Validator already exists in BeaconChain");
         ssvRegisteredValidators[pubkey] = true;
 
         emit SSVNetwork___ValidatorRegistered(pubkey);

--- a/src/BeaconChain.sol
+++ b/src/BeaconChain.sol
@@ -473,12 +473,7 @@ contract BeaconChain {
             validator.status = Status.EXITED;
             emit BeaconChain___StatusChanged(pubkey, validator.amount, Status.DEPOSITED, Status.EXITED);
         }
-        if (validator.status == Status.ACTIVE) {
-            validator.slashedAmount += MIN_SLASHING_PENALTY; // Apply minimum slashing penalty
-            validator.status = Status.EXITED;
-            emit BeaconChain___ValidatorSlashed(pubkey, MIN_SLASHING_PENALTY);
-            emit BeaconChain___StatusChanged(pubkey, validator.amount, validator.status, Status.EXITED);
-        }
+        if (validator.status == Status.ACTIVE) slash(pubkey, MIN_SLASHING_PENALTY); // Slash and exit
 
         ssvRegisteredValidators[pubkey] = false;
         emit SSVNetwork___ValidatorRemoved(pubkey);

--- a/src/BeaconProofs.sol
+++ b/src/BeaconProofs.sol
@@ -103,11 +103,11 @@ contract BeaconProofs is ValidatorSet {
         uint64, /*withdrawableEpoch*/
         bytes memory withdrawableEpochProof
     ) public view {
-        // 1. Convert withdrawableEpochProof to bytes32 deposit uid
-        bytes32 uid = bytes32(withdrawableEpochProof);
+        // 1. Convert withdrawableEpochProof to bytes32 deposit udid
+        bytes32 udid = bytes32(withdrawableEpochProof);
 
         // 2. Check that the deposit has been processed
-        require(beaconChain.processedDeposits(uid), "Beacon Proofs: Deposit not yet processed or doesn't exist");
+        require(beaconChain.processedDeposits(udid), "Beacon Proofs: Deposit not yet processed or doesn't exist");
     }
 
     function verifyBalancesContainer(

--- a/src/BeaconProofs.sol
+++ b/src/BeaconProofs.sol
@@ -32,10 +32,11 @@ contract BeaconProofs is ValidatorSet {
         bytes32 pubKeyHash,
         bytes calldata withdrawalCredentials,
         uint64 amountGwei,
-        bytes calldata, /*signature*/
-        uint64 /*slot*/
+        bytes calldata signature,
+        uint64 slot
     ) public pure returns (bytes32) {
-        return keccak256(abi.encodePacked(pubKeyHash, withdrawalCredentials, amountGwei /*, signature, slot*/ ));
+        slot; // to silence solc warning about unused variable
+        return keccak256(abi.encodePacked(pubKeyHash, withdrawalCredentials, amountGwei, signature));
     }
 
     /// @notice Verify that a validator with the given index and withdrawal address corresponds to the given pubKeyHash
@@ -98,25 +99,15 @@ contract BeaconProofs is ValidatorSet {
     /// @param withdrawableEpochProof is used to pass the unique deposit identifier
     function verifyValidatorWithdrawable(
         bytes32, /*beaconBlockRoot*/
-        uint40 validatorIndex,
+        uint40, /*validatorIndex*/
         uint64, /*withdrawableEpoch*/
         bytes memory withdrawableEpochProof
     ) public view {
-        // Find the uinque deposit corresponding to the validator
-        // 1. Find the pubkey from the index
-        bytes memory pubkey = indexToPubkey[validatorIndex];
+        // 1. Convert withdrawableEpochProof to bytes32 deposit uid
+        bytes32 uid = bytes32(withdrawableEpochProof);
 
-        // 2. Convert withdrawableEpochProof to uint256 deposit uid uint256
-        uint256 uid = uint256(bytes32(withdrawableEpochProof));
-
-        // 3. Browse the deposit queue to find a deposit with the same pubkey and uid, revert if it find the deposit
-        BeaconChain.Queue[] memory depositQueue = beaconChain.getDepositQueue();
-        uint256 len = depositQueue.length;
-        for (uint256 i = 0; i < len; i++) {
-            if (depositQueue[i].pubkey.eq(pubkey)) {
-                require(depositQueue[i].uid == uid, "Beacon Proofs: Deposit not yet processed");
-            }
-        }
+        // 2. Check that the deposit has been processed
+        require(beaconChain.processedDeposits(uid), "Beacon Proofs: Deposit not yet processed or doesn't exist");
     }
 
     function verifyBalancesContainer(

--- a/src/DepositContract.sol
+++ b/src/DepositContract.sol
@@ -9,6 +9,9 @@ contract DepositContract {
     ////////////////////////////////////////////////////
     BeaconChain public beaconChain;
 
+    /// @notice Unique counter for deposits, starting at 100 to avoid confusion with 0
+    uint256 public uniqueDepositId = 100;
+
     ////////////////////////////////////////////////////
     /// --- CONSTRUCTOR
     ////////////////////////////////////////////////////
@@ -29,6 +32,7 @@ contract DepositContract {
         bytes memory signature,
         bytes32 depositDataRoot
     ) external payable {
+        uniqueDepositId++;
         beaconChain.deposit{ value: msg.value }(pubkey, withdrawalCredentials, signature, depositDataRoot);
     }
 }

--- a/src/Ignite.sol
+++ b/src/Ignite.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.29;
+
+import { CompoundingStakingSSVStrategy } from "@origin-dollar/strategies/NativeStaking/CompoundingStakingSSVStrategy.sol";
+
+contract Ignite {
+    CompoundingStakingSSVStrategy public strategy;
+}
+
+/// @notice Some notes
+/// Mutative:
+/// - registerSsvValidator
+/// - stakeEth
+/// - validatorWithdrawal
+/// - removeSsvValidator
+/// - snapBalances
+/// Verification:
+/// - verifyValidator
+/// - verifyDeposit
+/// - verifyBalances
+/// Governor-only:
+/// - withdrawSSV
+/// - setRegistrator
+/// - resetFirstDeposit
+
+/// Path:
+/// 1. registerSsvValidator
+/// 2. stakeEth
+/// 3. verifyValidator
+/// 4. verifyDeposit
+/// 5. snapBalances
+/// 6. verifyBalances

--- a/src/ValidatorSet.sol
+++ b/src/ValidatorSet.sol
@@ -3,9 +3,11 @@ pragma solidity 0.8.29;
 
 // Utils
 import { LibBytes } from "@solady/utils/LibBytes.sol";
+import { SafeCastLib } from "@solady/utils/SafeCastLib.sol";
 
 contract ValidatorSet {
     using LibBytes for bytes;
+    using SafeCastLib for uint256;
 
     ////////////////////////////////////////////////////
     /// --- STRUCTS & ENUMS
@@ -63,6 +65,7 @@ contract ValidatorSet {
     Validator[] public validators;
 
     mapping(bytes pubkey => uint40 index) public pubkeyToIndex;
+    mapping(uint40 index => bytes pubkey) public indexToPubkey;
     mapping(bytes pubkey => bytes32) public pubkeyToHash;
     mapping(bytes32 pubkeyHash => bytes pubkey) public hashToPubkey;
 
@@ -94,6 +97,7 @@ contract ValidatorSet {
 
         for (uint256 i = 0; i < validators.length; i++) {
             pubkeyToIndex[validators[i].pubkey] = validators[i].index;
+            indexToPubkey[validators[i].index] = validators[i].pubkey;
 
             bytes32 pubKeyHash = hashPubKey(validators[i].pubkey);
             pubkeyToHash[validators[i].pubkey] = pubKeyHash;
@@ -110,5 +114,11 @@ contract ValidatorSet {
     ) public pure returns (bytes32) {
         require(pubKey.length == 48, "Invalid public key length");
         return sha256(abi.encodePacked(pubKey, bytes16(0)));
+    }
+
+    function withdrawCredentials(
+        address addr
+    ) public pure returns (bytes memory) {
+        return abi.encodePacked(bytes1(0x02), bytes11(0), addr);
     }
 }

--- a/src/mock/MockERC20.sol
+++ b/src/mock/MockERC20.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.29;
+
+// Solmate
+import { ERC20 } from "@solmate/tokens/ERC20.sol";
+
+contract MockERC20 is ERC20 {
+    constructor(string memory _name, string memory _symbol, uint8 _decimals) ERC20(_name, _symbol, _decimals) { }
+
+    function mint(address to, uint256 value) public virtual {
+        _mint(to, value);
+    }
+
+    function burn(address from, uint256 value) public virtual {
+        _burn(from, value);
+    }
+}

--- a/src/mock/MockWETH.sol
+++ b/src/mock/MockWETH.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.29;
+
+// Solmate
+import { WETH } from "@solmate/tokens/WETH.sol";
+
+contract MockWETH is WETH {
+    function mint(address to, uint256 value) public virtual {
+        _mint(to, value);
+    }
+
+    function burn(address from, uint256 value) public virtual {
+        _burn(from, value);
+    }
+}

--- a/test/Base.sol
+++ b/test/Base.sol
@@ -10,8 +10,8 @@ import { CompoundingStakingSSVStrategy } from "@origin-dollar/strategies/NativeS
 import { CompoundingStakingSSVStrategyProxy } from "@origin-dollar/proxies/Proxies.sol";
 
 // Mocks
-import { WETH } from "@solmate/tokens/WETH.sol";
-import { ERC20 } from "@solmate/tokens/ERC20.sol";
+import { MockWETH } from "../src/mock/MockWETH.sol";
+import { MockERC20 } from "../src/mock/MockERC20.sol";
 import { SSVNetwork } from "../src/SSVNetwork.sol";
 import { BeaconRoot } from "../src/BeaconRoot.sol";
 import { BeaconChain } from "../src/BeaconChain.sol";
@@ -52,8 +52,8 @@ contract Base is Test {
     CompoundingStakingSSVStrategyProxy public strategyProxy;
 
     // Mocks
-    WETH public weth;
-    ERC20 public ssv;
+    MockWETH public weth;
+    MockERC20 public ssv;
     SSVNetwork public ssvNetwork;
     BeaconRoot public beaconRoot;
     BeaconChain public beaconChain;

--- a/test/Base.sol
+++ b/test/Base.sol
@@ -7,6 +7,7 @@ import { Test } from "@forge-std/Test.sol";
 // Contract to test
 import { Cluster } from "@origin-dollar/interfaces/ISSVNetwork.sol";
 import { CompoundingStakingSSVStrategy } from "@origin-dollar/strategies/NativeStaking/CompoundingStakingSSVStrategy.sol";
+import { CompoundingStakingStrategyView } from "@origin-dollar/strategies/NativeStaking/CompoundingStakingView.sol";
 import { CompoundingStakingSSVStrategyProxy } from "@origin-dollar/proxies/Proxies.sol";
 
 // Mocks
@@ -49,6 +50,7 @@ contract Base is Test {
     ////////////////////////////////////////////////////
     // Contracts
     CompoundingStakingSSVStrategy public strategy;
+    CompoundingStakingStrategyView public strategyView;
     CompoundingStakingSSVStrategyProxy public strategyProxy;
 
     // Mocks

--- a/test/Setup.sol
+++ b/test/Setup.sol
@@ -73,6 +73,7 @@ contract Setup is Base, ValidatorSet {
 
         // Then deploy BeaconProofs contract
         beaconProofs = new BeaconProofs(address(beaconChain));
+        beaconChain.setBeaconProofs(address(beaconProofs));
 
         // Deploy DepositContract and PartialWithdrawContract to their respective addresses on mainnet
         deployCodeTo("BeaconRoot.sol", abi.encode(), BEACON_ROOTS_ADDRESS);

--- a/test/Setup.sol
+++ b/test/Setup.sol
@@ -10,9 +10,8 @@ import { CompoundingStakingSSVStrategy } from "@origin-dollar/strategies/NativeS
 import { CompoundingStakingSSVStrategyProxy } from "@origin-dollar/proxies/Proxies.sol";
 
 // Mocks
-import { WETH } from "@solmate/tokens/WETH.sol";
-import { ERC20 } from "@solmate/tokens/ERC20.sol";
-import { MockERC20 } from "@solmate/test/utils/mocks/MockERC20.sol";
+import { MockWETH } from "../src/mock/MockWETH.sol";
+import { MockERC20 } from "../src/mock/MockERC20.sol";
 import { SSVNetwork } from "../src/SSVNetwork.sol";
 import { BeaconRoot } from "../src/BeaconRoot.sol";
 import { BeaconChain } from "../src/BeaconChain.sol";
@@ -90,8 +89,8 @@ contract Setup is Base, ValidatorSet {
         deal(address(beaconChain.REWARD_DISTRIBUTOR()), 1_000_000 ether);
 
         // Deploy WETH and SSV token
-        ssv = ERC20(address(new MockERC20("SSV Token", "SSV", 18)));
-        weth = new WETH();
+        ssv = new MockERC20("SSV Token", "SSV", 18);
+        weth = new MockWETH();
     }
 
     //////////////////////////////////////////////////////

--- a/test/Setup.sol
+++ b/test/Setup.sol
@@ -7,6 +7,7 @@ import { Base } from "./Base.sol";
 // Contract to test
 import { InitializableAbstractStrategy } from "@origin-dollar/utils/InitializableAbstractStrategy.sol";
 import { CompoundingStakingSSVStrategy } from "@origin-dollar/strategies/NativeStaking/CompoundingStakingSSVStrategy.sol";
+import { CompoundingStakingStrategyView } from "@origin-dollar/strategies/NativeStaking/CompoundingStakingView.sol";
 import { CompoundingStakingSSVStrategyProxy } from "@origin-dollar/proxies/Proxies.sol";
 
 // Mocks
@@ -131,6 +132,10 @@ contract Setup is Base, ValidatorSet {
         // Set logic contract on proxy
         strategy = CompoundingStakingSSVStrategy(payable(address(strategyProxy)));
 
+        // ---
+        // --- 4. Deploy view contract. ---
+        strategyView = new CompoundingStakingStrategyView(address(strategy));
+
         vm.stopPrank();
     }
 
@@ -151,6 +156,7 @@ contract Setup is Base, ValidatorSet {
         // Strategy
         vm.label(address(strategy), "CompoundingStakingSSVStrategy");
         vm.label(address(strategyProxy), "CompoundingStakingSSVStrategy Proxy");
+        vm.label(address(strategyView), "CompoundingStakingSSVStrategy View");
 
         // Mocks
         vm.label(address(beaconRoot), "BeaconRoot");

--- a/test/beacon_chain/Deposit.sol
+++ b/test/beacon_chain/Deposit.sol
@@ -36,7 +36,7 @@ contract Deposit_Test is Setup {
 
         // Activate validator 1
         beaconChain.getValidatorLength();
-        beaconChain.activateValidator();
+        beaconChain.activateValidators();
         beaconChain.getValidatorLength();
 
         // Check validator state
@@ -74,7 +74,7 @@ contract Deposit_Test is Setup {
 
         beaconChain.processDeposit(0);
         beaconChain.processDeposit(0);
-        beaconChain.activateValidator();
+        beaconChain.activateValidators();
 
         // Check validator state
         checkValidatorState();

--- a/test/beacon_chain/Deposit.sol
+++ b/test/beacon_chain/Deposit.sol
@@ -22,10 +22,18 @@ contract Deposit_Test is Setup {
 
         // Stake 1 ETH
         weth.mint(address(strategy), 1 ether);
-        vm.prank(operator);
-        strategy.stakeEth(
-            CompoundingValidatorManager.ValidatorStakeData(validator1.pubkey, bytes(""), bytes32(0)), 1 ether / 1 gwei
-        );
+        vm.startPrank(operator);
+        strategy.stakeEth({
+            validatorStakeData: CompoundingValidatorManager.ValidatorStakeData({
+                pubkey: validator1.pubkey,
+                signature: abi.encodePacked(beaconChain.uniqueDepositId()),
+                depositDataRoot: bytes32(0)
+            }),
+            depositAmountGwei: 1 ether / 1 gwei
+        });
+        vm.stopPrank();
+        // increase uniqueDepositId
+        beaconChain.increaseUniqueDepositId();
 
         // Verify validator
         strategy.verifyValidator(0, validator1.index, hashPubKey(validator1.pubkey), address(strategy), bytes(""));
@@ -41,8 +49,8 @@ contract Deposit_Test is Setup {
             firstPendingDeposit: CompoundingValidatorManager.FirstPendingDepositSlotProofData({ slot: 1, proof: bytes("") }),
             strategyValidatorData: CompoundingValidatorManager.StrategyValidatorProofData({
                 withdrawableEpoch: type(uint64).max,
-                withdrawableEpochProof: abi.encodePacked(uint256(1)) // Todo find something better for the UID.
-             })
+                withdrawableEpochProof: abi.encodePacked(deposits[0].pendingDepositRoot)
+            })
         });
     }
 }

--- a/test/beacon_chain/Deposit.sol
+++ b/test/beacon_chain/Deposit.sol
@@ -12,96 +12,6 @@ contract Deposit_Test is Setup {
         super.setUp();
     }
 
-    function test_Direct_BC_Deposit() public {
-        uint256 depositAmount = 1 ether;
-
-        beaconChain.registerSsvValidator(validator1.pubkey);
-        beaconChain.registerSsvValidator(validator2.pubkey);
-
-        // Deposit
-        vm.startPrank(alice);
-        beaconChain.deposit{ value: depositAmount * 10 }(validator1.pubkey, aliceWithdrawalCredentials, "", "");
-        beaconChain.deposit{ value: depositAmount * 22 }(validator1.pubkey, aliceWithdrawalCredentials, "", "");
-        beaconChain.deposit{ value: depositAmount * 12 }(validator2.pubkey, aliceWithdrawalCredentials, "", "");
-
-        // Check deposit queue
-        beaconChain.getDepositQueue();
-
-        // Process deposits
-        beaconChain.processDeposit();
-        beaconChain.processDeposit();
-
-        // Check validator state
-        checkValidatorState();
-
-        // Activate validator 1
-        beaconChain.getValidatorLength();
-        beaconChain.activateValidators();
-        beaconChain.getValidatorLength();
-
-        // Check validator state
-        checkValidatorState();
-
-        // Withdraw from validator 1
-        beaconChain.withdraw(validator1.pubkey, depositAmount * 5);
-        beaconChain.processWithdraw();
-
-        // Check validator state
-        checkValidatorState();
-
-        // Withdraw more than remaining balance
-        beaconChain.withdraw(validator1.pubkey, depositAmount * 18);
-        beaconChain.processWithdraw();
-
-        // Check validator state
-        checkValidatorState();
-
-        // Check validator state
-        checkValidatorState();
-
-        // Sweep
-        beaconChain.processSweep();
-
-        // Check validator state
-        checkValidatorState();
-
-        // Deposit more to validator 2
-        beaconChain.deposit{ value: depositAmount * 2035 }(validator2.pubkey, aliceWithdrawalCredentials, "", "");
-        checkValidatorState();
-
-        beaconChain.processDeposit();
-        beaconChain.processDeposit();
-        beaconChain.activateValidators();
-
-        // Check validator state
-        checkValidatorState();
-
-        // Simulate some rewards on validator 2
-        beaconChain.simulateRewards(validator2.pubkey, 2 ether);
-
-        // Check validator state
-        checkValidatorState();
-
-        // Process sweep
-        beaconChain.processSweep();
-
-        // Check validator state
-        checkValidatorState();
-
-        // Slash validator 2 by 2040 ether
-        beaconChain.slash(validator2.pubkey, 2040 ether);
-
-        beaconChain.processSweep();
-
-        vm.stopPrank();
-    }
-
-    function checkValidatorState() public view {
-        beaconChain.getDepositQueue();
-        beaconChain.getWithdrawQueue();
-        beaconChain.getValidators();
-    }
-
     function test_Deposit() public {
         // Register a validator on SSV
         vm.prank(operator);
@@ -112,7 +22,7 @@ contract Deposit_Test is Setup {
         vm.prank(alice);
         depositContract.deposit{ value: 1 ether }(validator1.pubkey, withdrawalCredentials, bytes(""), bytes32(0));
         // Stake 1 ETH
-        deal(address(weth), address(strategy), 1 ether);
+        weth.mint(address(strategy), 1 ether);
         vm.prank(operator);
         strategy.stakeEth(
             CompoundingValidatorManager.ValidatorStakeData(validator1.pubkey, bytes(""), bytes32(0)), 1 ether / 1 gwei

--- a/test/beacon_chain/Deposit.sol
+++ b/test/beacon_chain/Deposit.sol
@@ -26,14 +26,12 @@ contract Deposit_Test is Setup {
         strategy.stakeEth({
             validatorStakeData: CompoundingValidatorManager.ValidatorStakeData({
                 pubkey: validator1.pubkey,
-                signature: abi.encodePacked(beaconChain.uniqueDepositId()),
+                signature: abi.encodePacked(depositContract.uniqueDepositId()),
                 depositDataRoot: bytes32(0)
             }),
             depositAmountGwei: 1 ether / 1 gwei
         });
         vm.stopPrank();
-        // increase uniqueDepositId
-        beaconChain.increaseUniqueDepositId();
 
         // Verify validator
         strategy.verifyValidator(0, validator1.index, hashPubKey(validator1.pubkey), address(strategy), bytes(""));

--- a/test/beacon_chain/Deposit.sol
+++ b/test/beacon_chain/Deposit.sol
@@ -44,20 +44,17 @@ contract Deposit_Test is Setup {
 
         // Withdraw from validator 1
         beaconChain.withdraw(validator1.pubkey, depositAmount * 5);
-        beaconChain.processWithdraw(0);
+        beaconChain.processWithdraw();
 
         // Check validator state
         checkValidatorState();
 
         // Withdraw more than remaining balance
         beaconChain.withdraw(validator1.pubkey, depositAmount * 18);
-        beaconChain.processWithdraw(0);
+        beaconChain.processWithdraw();
 
         // Check validator state
         checkValidatorState();
-
-        // Process exit
-        beaconChain.processExit(0);
 
         // Check validator state
         checkValidatorState();
@@ -94,7 +91,6 @@ contract Deposit_Test is Setup {
         // Slash validator 2 by 2040 ether
         beaconChain.slash(validator2.pubkey, 2040 ether);
 
-        beaconChain.processExit(0);
         beaconChain.processSweep();
 
         vm.stopPrank();
@@ -103,7 +99,6 @@ contract Deposit_Test is Setup {
     function checkValidatorState() public view {
         beaconChain.getDepositQueue();
         beaconChain.getWithdrawQueue();
-        beaconChain.getExitQueue();
         beaconChain.getValidators();
     }
 

--- a/test/beacon_chain/Deposit.sol
+++ b/test/beacon_chain/Deposit.sol
@@ -28,8 +28,8 @@ contract Deposit_Test is Setup {
         beaconChain.getDepositQueue();
 
         // Process deposits
-        beaconChain.processDeposit(0);
-        beaconChain.processDeposit(0);
+        beaconChain.processDeposit();
+        beaconChain.processDeposit();
 
         // Check validator state
         checkValidatorState();
@@ -72,8 +72,8 @@ contract Deposit_Test is Setup {
         beaconChain.deposit{ value: depositAmount * 2035 }(validator2.pubkey, aliceWithdrawalCredentials, "", "");
         checkValidatorState();
 
-        beaconChain.processDeposit(0);
-        beaconChain.processDeposit(0);
+        beaconChain.processDeposit();
+        beaconChain.processDeposit();
         beaconChain.activateValidators();
 
         // Check validator state


### PR DESCRIPTION
## Description

### processDeposit should:
- [x] immediately credit the deposited amount to the validator balance unless a validator is exiting. In such case the deposit should be postponed like it is. If validator is ValidatorStatus.DEPOSITED just update its balance
- [x] would be nice to emit a different event whether validator is ACTIVE or WITHDRAWABLE state 

### Activate validator:
- [x] should traverse the list of validators that are DEPOSITED and activate the first validator that meets the the minimum activation requirement. There is probably no need for a `pendingQueue`

### withdraw:
- [x] needs to verify that the validator is ACTIVE. If not the withdraw request is ignored. 
- [x] all withdraw checks need to happen at the time of processing the withdrawal request and not at the time of adding it to the queue. Other state changing operations can alter the balance / state of the validator which can be different at the time withdrawal requests are received to the time withdrawal requests are processed
- [x]  partial withdrawals are only allowed in a manner where validator after the withdrawal still has 32 ETH. E.g. validator has 36 ETH, partial withdrawal of 6 ETH is requested. Withdrawal is ignored
- [x] full withdrawals (amount == 0) clears up complete validator balance, but not immediately. Validator needs to wait (say fixed period) with its balance intact. When the validator transitions to WITHDRAWABLE then the sweep cycle will collect the balance
- [x] validators don't voluntarily exit when their amount goes to 16 ETH. Rather their amount can never go below 32 ETH unless a slashing or full withdrawal have been requested
- [x] when a full exit is requested or slashing happens the validator balance will remain on the validator. Only once the sweep cycle gets to it then it is sent to the owner. As opposed to partial withdrawals where we can simulate that the funds hit the owner's wallet immediately

### removeSsvValidator:
 - [x] you can remove the ssv validator while it is still active. It will result in slashing.

### slash:
 - [x] validator is always slashed for 1 ETH (minimum)
 - [x] after the 1 ETH slashed the validator is forcefully exited ( ValidatorStatus.EXITED). Which is similar to a full withdrawal except that the wait time is longer. Lets say 30 days or something smaller for the purpose of fuzz tests. The validator balance remains on the validator for that period. After the period it is withdrawable, and withdrawn once the sweep cycle gets to it

### slash & full withdrawal:
 - [x] both full withdraw processed and slash should immediately put the validator into the ValidatorStatus.EXITED state
 - [x] after some fixed time period -> for fuzz tests it can be simplified to either number of blocks or time passed (whichever is easier) the validators switch their state from EXITED to WITHDRAWABLE