### PR TITLE
✨ Handle `verifyDeposit` with shortcuts.

### DIFF
--- a/src/BeaconChain.sol
+++ b/src/BeaconChain.sol
@@ -66,7 +66,6 @@ contract BeaconChain {
     Queue[] public withdrawQueue;
     Validator[] public validators; // unordered list of validator
 
-    uint256 public uniqueDepositId = 100; // unique identifier for deposits, starting at 100 to avoid confusion with 0
     mapping(bytes32 id => bool processed) public processedDeposits; // to help tracking processed deposits
     mapping(bytes pubkey => bool registered) public ssvRegisteredValidators; // mapping of SSV registered validators
 
@@ -522,11 +521,6 @@ contract BeaconChain {
     /// @return The minimum value.
     function min(uint256 a, uint256 b) public pure returns (uint256) {
         return a < b ? a : b;
-    }
-
-    /// @notice Increases the unique deposit ID (for testing purposes).
-    function increaseUniqueDepositId() public {
-        uniqueDepositId++;
     }
 
     /// @notice Sets the BeaconProofs contract address.

--- a/src/BeaconChain.sol
+++ b/src/BeaconChain.sol
@@ -49,7 +49,7 @@ contract BeaconChain {
         uint64 timestamp;
         uint256 amount; // in wei
         address owner;
-        bytes32 uid;
+        bytes32 udid;
     }
 
     struct Validator {
@@ -120,9 +120,9 @@ contract BeaconChain {
                 pubkey: pubkey,
                 timestamp: uint64(block.timestamp),
                 owner: decodeOwner(withdrawalCredentials),
-                // recreate the pendingDepositRoot, that will be used as unique identifier of the deposit
+                // recreate the pendingDepositRoot, that will be used as unique deposit ID
                 // signature is the value responsible to make the deposit unique
-                uid: beaconProofs.merkleizePendingDeposit({
+                udid: beaconProofs.merkleizePendingDeposit({
                     pubKeyHash: beaconProofs.hashPubKey(pubkey),
                     withdrawalCredentials: withdrawalCredentials,
                     amountGwei: (msg.value / 1 gwei).toUint64(),
@@ -160,7 +160,7 @@ contract BeaconChain {
                     status: Status.DEPOSITED
                 })
             );
-            processedDeposits[pendingDeposit.uid] = true;
+            processedDeposits[pendingDeposit.udid] = true;
             emit BeaconChain___ValidatorCreated(pubkey);
             emit BeaconChain___StatusChanged(pubkey, pendingDeposit.amount, Status.UNKNOWN, Status.DEPOSITED);
             emit BeaconChain___DepositProcessed(pubkey, pendingDeposit.amount, Status.DEPOSITED);
@@ -182,7 +182,7 @@ contract BeaconChain {
 
         // --- 2.c. Validator exists and is either DEPOSITED, ACTIVE or WITHDRAWABLE: increase stake
         validator.amount += pendingDeposit.amount;
-        processedDeposits[pendingDeposit.uid] = true;
+        processedDeposits[pendingDeposit.udid] = true;
         emit BeaconChain___DepositProcessed(pubkey, pendingDeposit.amount, currentStatus);
     }
 
@@ -208,7 +208,7 @@ contract BeaconChain {
     /// @dev Only the owner can request withdrawal.
     function withdraw(bytes calldata pubkey, uint256 amount) external {
         withdrawQueue.push(
-            Queue({ pubkey: pubkey, amount: amount, timestamp: uint64(block.timestamp), owner: address(0), uid: 0 })
+            Queue({ pubkey: pubkey, amount: amount, timestamp: uint64(block.timestamp), owner: address(0), udid: 0 })
         );
         emit BeaconChain___Withdraw(pubkey, amount);
     }

--- a/src/BeaconProofs.sol
+++ b/src/BeaconProofs.sol
@@ -103,11 +103,11 @@ contract BeaconProofs is ValidatorSet {
         uint64, /*withdrawableEpoch*/
         bytes memory withdrawableEpochProof
     ) public view {
-        // 1. Convert withdrawableEpochProof to bytes32 deposit uid
-        bytes32 uid = bytes32(withdrawableEpochProof);
+        // 1. Convert withdrawableEpochProof to bytes32 deposit udid
+        bytes32 udid = bytes32(withdrawableEpochProof);
 
         // 2. Check that the deposit has been processed
-        require(beaconChain.processedDeposits(uid), "Beacon Proofs: Deposit not yet processed or doesn't exist");
+        require(beaconChain.processedDeposits(udid), "Beacon Proofs: Deposit not yet processed or doesn't exist");
     }
 
     function verifyBalancesContainer(

--- a/src/BeaconProofs.sol
+++ b/src/BeaconProofs.sol
@@ -32,10 +32,11 @@ contract BeaconProofs is ValidatorSet {
         bytes32 pubKeyHash,
         bytes calldata withdrawalCredentials,
         uint64 amountGwei,
-        bytes calldata, /*signature*/
-        uint64 /*slot*/
+        bytes calldata signature,
+        uint64 slot
     ) public pure returns (bytes32) {
-        return keccak256(abi.encodePacked(pubKeyHash, withdrawalCredentials, amountGwei /*, signature, slot*/ ));
+        slot; // to silence solc warning about unused variable
+        return keccak256(abi.encodePacked(pubKeyHash, withdrawalCredentials, amountGwei, signature));
     }
 
     /// @notice Verify that a validator with the given index and withdrawal address corresponds to the given pubKeyHash
@@ -98,25 +99,15 @@ contract BeaconProofs is ValidatorSet {
     /// @param withdrawableEpochProof is used to pass the unique deposit identifier
     function verifyValidatorWithdrawable(
         bytes32, /*beaconBlockRoot*/
-        uint40 validatorIndex,
+        uint40, /*validatorIndex*/
         uint64, /*withdrawableEpoch*/
         bytes memory withdrawableEpochProof
     ) public view {
-        // Find the uinque deposit corresponding to the validator
-        // 1. Find the pubkey from the index
-        bytes memory pubkey = indexToPubkey[validatorIndex];
+        // 1. Convert withdrawableEpochProof to bytes32 deposit uid
+        bytes32 uid = bytes32(withdrawableEpochProof);
 
-        // 2. Convert withdrawableEpochProof to uint256 deposit uid uint256
-        uint256 uid = uint256(bytes32(withdrawableEpochProof));
-
-        // 3. Browse the deposit queue to find a deposit with the same pubkey and uid, revert if it find the deposit
-        BeaconChain.Queue[] memory depositQueue = beaconChain.getDepositQueue();
-        uint256 len = depositQueue.length;
-        for (uint256 i = 0; i < len; i++) {
-            if (depositQueue[i].pubkey.eq(pubkey)) {
-                require(depositQueue[i].uid == uid, "Beacon Proofs: Deposit not yet processed");
-            }
-        }
+        // 2. Check that the deposit has been processed
+        require(beaconChain.processedDeposits(uid), "Beacon Proofs: Deposit not yet processed or doesn't exist");
     }
 
     function verifyBalancesContainer(

--- a/src/DepositContract.sol
+++ b/src/DepositContract.sol
@@ -9,6 +9,9 @@ contract DepositContract {
     ////////////////////////////////////////////////////
     BeaconChain public beaconChain;
 
+    /// @notice Unique counter for deposits, starting at 100 to avoid confusion with 0
+    uint256 public uniqueDepositId = 100;
+
     ////////////////////////////////////////////////////
     /// --- CONSTRUCTOR
     ////////////////////////////////////////////////////
@@ -29,6 +32,7 @@ contract DepositContract {
         bytes memory signature,
         bytes32 depositDataRoot
     ) external payable {
+        uniqueDepositId++;
         beaconChain.deposit{ value: msg.value }(pubkey, withdrawalCredentials, signature, depositDataRoot);
     }
 }

--- a/test/Setup.sol
+++ b/test/Setup.sol
@@ -73,6 +73,7 @@ contract Setup is Base, ValidatorSet {
 
         // Then deploy BeaconProofs contract
         beaconProofs = new BeaconProofs(address(beaconChain));
+        beaconChain.setBeaconProofs(address(beaconProofs));
 
         // Deploy DepositContract and PartialWithdrawContract to their respective addresses on mainnet
         deployCodeTo("BeaconRoot.sol", abi.encode(), BEACON_ROOTS_ADDRESS);

--- a/test/beacon_chain/Deposit.sol
+++ b/test/beacon_chain/Deposit.sol
@@ -22,10 +22,18 @@ contract Deposit_Test is Setup {
 
         // Stake 1 ETH
         weth.mint(address(strategy), 1 ether);
-        vm.prank(operator);
-        strategy.stakeEth(
-            CompoundingValidatorManager.ValidatorStakeData(validator1.pubkey, bytes(""), bytes32(0)), 1 ether / 1 gwei
-        );
+        vm.startPrank(operator);
+        strategy.stakeEth({
+            validatorStakeData: CompoundingValidatorManager.ValidatorStakeData({
+                pubkey: validator1.pubkey,
+                signature: abi.encodePacked(beaconChain.uniqueDepositId()),
+                depositDataRoot: bytes32(0)
+            }),
+            depositAmountGwei: 1 ether / 1 gwei
+        });
+        vm.stopPrank();
+        // increase uniqueDepositId
+        beaconChain.increaseUniqueDepositId();
 
         // Verify validator
         strategy.verifyValidator(0, validator1.index, hashPubKey(validator1.pubkey), address(strategy), bytes(""));
@@ -41,8 +49,8 @@ contract Deposit_Test is Setup {
             firstPendingDeposit: CompoundingValidatorManager.FirstPendingDepositSlotProofData({ slot: 1, proof: bytes("") }),
             strategyValidatorData: CompoundingValidatorManager.StrategyValidatorProofData({
                 withdrawableEpoch: type(uint64).max,
-                withdrawableEpochProof: abi.encodePacked(uint256(1)) // Todo find something better for the UID.
-             })
+                withdrawableEpochProof: abi.encodePacked(deposits[0].pendingDepositRoot)
+            })
         });
     }
 }

--- a/test/beacon_chain/Deposit.sol
+++ b/test/beacon_chain/Deposit.sol
@@ -26,14 +26,12 @@ contract Deposit_Test is Setup {
         strategy.stakeEth({
             validatorStakeData: CompoundingValidatorManager.ValidatorStakeData({
                 pubkey: validator1.pubkey,
-                signature: abi.encodePacked(beaconChain.uniqueDepositId()),
+                signature: abi.encodePacked(depositContract.uniqueDepositId()),
                 depositDataRoot: bytes32(0)
             }),
             depositAmountGwei: 1 ether / 1 gwei
         });
         vm.stopPrank();
-        // increase uniqueDepositId
-        beaconChain.increaseUniqueDepositId();
 
         // Verify validator
         strategy.verifyValidator(0, validator1.index, hashPubKey(validator1.pubkey), address(strategy), bytes(""));


### PR DESCRIPTION
# Description 
This PR aims to do the job of `verifyDeposit` -> ensure that a deposit has been processed by the beacon chain. Thanks to the communication between the execute chain and consensus chain (for testing ofc), it is possible to take some shortcuts. 

### How does it work?
- The shortcut is: directly check that the deposit has been processed, by creating a unique deposit ID at the deposit. This ID will be the `pendingDepositRoot`. So this ID will be pushed in the `depositQueue` when a deposit happen on the BeaconChain, alongside other params like `owner`, `pubkey`, `amount`.
- When the BeaconChain `processDeposit`, if the deposit meet the criteria and is not discarded or postponed, the mapping `processedDeposits` will be set to `true`.
- Thus, this is really easy to check if a deposit has been processed or not. 

### How `verifyDeposit` handles it?
- The verification happening in `verifyDeposit` will be a bit different than the expected behavior. As we don't verify merkle proof and all what's related to slot logic, the idea is to go straight to the point and only verify internal contract state like:
```solidity
require(deposit.status == DepositStatus.PENDING, "Deposit not pending");
...
require(
    strategyValidator.state == ValidatorState.VERIFIED ||
        strategyValidator.state == ValidatorState.EXITING,
    "Validator not verified/exiting"
);
... 
_removeDeposit(pendingDepositRoot, deposit);
```
- Checking that the deposit has been processed (which is the most important part) will happen in the `verifyValidatorWithdrawable`. Even if this is not the purpose of this function, as it is the only time we call it, we can change the behavior of it, for the testing purpose, as we have our own implementation of the BeaconProofs.
- `verifyValidatorWithdrawable` behavior will be changed and simply go to the BeaconChain and check the `processDeposit`. 

### How to pass data to `verifyValidatorWithdrawable`?
- The easiest way to pass the unique deposit ID to `verifyValidatorWithdrawable` is to pass it as argument, as we don't use all of the argument of `verifyDeposit` due to our shortcut, we can pick the one that is less used. 
- It will be `StrategyValidatorProofData.withdrawableEpochProof`, as this is only used in `verifyValidatorWithdrawable` call. 

### How convenient is it to use in test? 
- Thank to the `CompoundingStakingStrategyView:getPendingDeposits`, it is really easy to get the list of pending deposit, with the corresponding `pendingDepositRoot` (the unique deposit ID!). 
```solidity
CompoundingStakingStrategyView.DepositView[] memory deposits = strategyView.getPendingDeposits();
strategy.verifyDeposit({
    pendingDepositRoot: deposits[0].pendingDepositRoot,
    depositProcessedSlot: deposits[0].slot + 1,
    firstPendingDeposit: CompoundingValidatorManager.FirstPendingDepositSlotProofData({ slot: 1, proof: bytes("") }),
    strategyValidatorData: CompoundingValidatorManager.StrategyValidatorProofData({
        withdrawableEpoch: type(uint64).max,
        withdrawableEpochProof: abi.encodePacked(deposits[0].pendingDepositRoot)
    })
});
```

### Note
It will be mandatory to call `increaseUniqueDepositId()` every time we call `stakeEth` on the strategy, to ensure unique deposit.